### PR TITLE
Runtime permission and security issue fix

### DIFF
--- a/CameraLibrary/app/build.gradle
+++ b/CameraLibrary/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 25
     buildToolsVersion "24.0.3"
 
     defaultConfig {
         applicationId "com.mindorks.cameralibrary"
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -28,7 +28,8 @@ repositories{
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile "com.android.support:support-v4:25.0.1"
 //    compile 'com.mindorks:paracamera:1.0.0'
     compile project(':paracamera')
 }

--- a/CameraLibrary/app/src/main/AndroidManifest.xml
+++ b/CameraLibrary/app/src/main/AndroidManifest.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mindorks.cameralibrary">
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="18" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -17,6 +18,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="com.mindorks.cameralibrary.MainActivity"/>
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/CameraLibrary/app/src/main/java/com/mindorks/cameralibrary/CameraFragment.java
+++ b/CameraLibrary/app/src/main/java/com/mindorks/cameralibrary/CameraFragment.java
@@ -1,10 +1,15 @@
 package com.mindorks.cameralibrary;
 
+import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.Fragment;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,17 +21,18 @@ import com.mindorks.paracamera.Camera;
 /**
  * Created by janisharali on 15/11/16.
  */
-
 public class CameraFragment extends Fragment {
 
     private ImageView picFrame;
     private Camera camera;
 
+    private static final int REQUEST_ALL_PERMISSION = 1;
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_camera, null);
-        picFrame = (ImageView)rootView.findViewById(R.id.picFrame);
+        picFrame = (ImageView) rootView.findViewById(R.id.picFrame);
         camera = new Camera(this);
         return rootView;
     }
@@ -42,24 +48,57 @@ public class CameraFragment extends Fragment {
                 .setImageFormat(Camera.IMAGE_JPEG)
                 .setCompression(75)
                 .setImageHeight(1000);
+
+        initPermission();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private void initPermission() {
+        if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (shouldShowRequestPermissionRationale(Manifest.permission.CAMERA) ||
+                    shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                Toast.makeText(getActivity(), "Need permission please", Toast.LENGTH_SHORT).show();
+            }
+            requestPermissions(new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE}, REQUEST_ALL_PERMISSION);
+        } else {
+            takePicture();
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        switch (requestCode) {
+            case REQUEST_ALL_PERMISSION:
+                if (grantResults.length > 0 &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    takePicture();
+                } else {
+                    Toast.makeText(getActivity(), "permission not granted", Toast.LENGTH_SHORT).show();
+                }
+                return;
+            default:
+                super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
+    }
+
+    void takePicture() {
         try {
             camera.takePicture();
-        }catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-
-
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if(requestCode == Camera.REQUEST_TAKE_PHOTO){
+        if (requestCode == Camera.REQUEST_TAKE_PHOTO) {
             Bitmap bitmap = camera.getCameraBitmap();
-            if(bitmap != null) {
+            if (bitmap != null) {
                 picFrame.setImageBitmap(bitmap);
-            }else{
-                Toast.makeText(getActivity().getApplicationContext(),"Picture not taken!",Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(getActivity().getApplicationContext(), "Picture not taken!", Toast.LENGTH_SHORT).show();
             }
         }
     }

--- a/CameraLibrary/app/src/main/java/com/mindorks/cameralibrary/MainActivity.java
+++ b/CameraLibrary/app/src/main/java/com/mindorks/cameralibrary/MainActivity.java
@@ -1,12 +1,15 @@
 package com.mindorks.cameralibrary;
 
+import android.Manifest;
+import android.annotation.TargetApi;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
-import android.net.Uri;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
+import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
+import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
 import android.widget.ImageView;
 import android.widget.Toast;
 
@@ -17,12 +20,14 @@ public class MainActivity extends AppCompatActivity {
     private ImageView picFrame;
     private Camera camera;
 
+    private static final int REQUEST_ALL_PERMISSION = 1;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        picFrame = (ImageView)findViewById(R.id.picFrame);
+        picFrame = (ImageView) findViewById(R.id.picFrame);
         camera = new Camera(this);
     }
 
@@ -35,9 +40,44 @@ public class MainActivity extends AppCompatActivity {
                 .setImageFormat(Camera.IMAGE_JPEG)
                 .setCompression(75)
                 .setImageHeight(1000);
+
+        initPermission();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private void initPermission() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (shouldShowRequestPermissionRationale(Manifest.permission.CAMERA) ||
+                    shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                Toast.makeText(this, "Need permission please", Toast.LENGTH_SHORT).show();
+            }
+            requestPermissions(new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE}, REQUEST_ALL_PERMISSION);
+        } else {
+            takePicture();
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        switch (requestCode) {
+            case REQUEST_ALL_PERMISSION:
+                if (grantResults.length > 0 &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    takePicture();
+                } else {
+                    Toast.makeText(this, "permission not granted", Toast.LENGTH_SHORT).show();
+                }
+                return;
+            default:
+                super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
+    }
+
+    void takePicture() {
         try {
             camera.takePicture();
-        }catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -45,12 +85,12 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if(requestCode == Camera.REQUEST_TAKE_PHOTO){
+        if (requestCode == Camera.REQUEST_TAKE_PHOTO) {
             Bitmap bitmap = camera.getCameraBitmap();
-            if(bitmap != null) {
+            if (bitmap != null) {
                 picFrame.setImageBitmap(bitmap);
-            }else{
-                Toast.makeText(this.getApplicationContext(),"Picture not taken!",Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this.getApplicationContext(), "Picture not taken!", Toast.LENGTH_SHORT).show();
             }
         }
     }

--- a/CameraLibrary/build.gradle
+++ b/CameraLibrary/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/CameraLibrary/paracamera/build.gradle
+++ b/CameraLibrary/paracamera/build.gradle
@@ -25,12 +25,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 25
     buildToolsVersion "24.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 4
         versionName "0.1.1"
     }
@@ -40,6 +40,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+}
+
+dependencies {
+    compile "com.android.support:support-v4:25.0.1"
 }
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'


### PR DESCRIPTION
1. Added runtime permission for Android 6.0 and above
2. Fixed file:// scheme security issue on Android N

Tested on devices with API 19 (4.4) and 24 (7.0)

More on file security on Android N: https://inthecheesefactory.com/blog/how-to-share-access-to-file-with-fileprovider-on-android-nougat/en